### PR TITLE
Support Swift Playgrounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 /*.xcodeproj
 xcuserdata/
 /.swiftpm
+
+# Swift Playground generated using GeneratePlayground.swift
+Playground/SwiftShortcuts.playgroundbook

--- a/Playground/GeneratePlayground.swift
+++ b/Playground/GeneratePlayground.swift
@@ -8,12 +8,12 @@ extension FileManager {
     }
 }
 
-let fileManager = FileManager()
-let isDebuggable: Bool = UserDefaults.standard.bool(forKey: "debug") // use -debug
+let fileManager = FileManager.default
+let isDebuggable = UserDefaults.standard.bool(forKey: "debug") // use -debug
 
 // Get the Playgrounds directory
 let playgroundsDirectory = URL(fileURLWithPath: fileManager.currentDirectoryPath)
-    .appendingPathComponent(CommandLine.arguments.first!)
+    .appendingPathComponent(CommandLine.arguments[0])
     .deletingLastPathComponent()
 
 // Read the version from the arguments

--- a/Playground/GeneratePlayground.swift
+++ b/Playground/GeneratePlayground.swift
@@ -1,0 +1,80 @@
+#!/usr/bin/swift
+import Foundation
+
+extension FileManager {
+    func directoryExists(at url: URL) -> Bool {
+        var isDirectory: ObjCBool = false
+        return fileExists(atPath: url.path, isDirectory: &isDirectory) && isDirectory.boolValue
+    }
+}
+
+let fileManager = FileManager()
+let isDebuggable: Bool = UserDefaults.standard.bool(forKey: "debug") // use -debug
+
+// Get the Playgrounds directory
+let playgroundsDirectory = URL(fileURLWithPath: fileManager.currentDirectoryPath)
+    .appendingPathComponent(CommandLine.arguments.first!)
+    .deletingLastPathComponent()
+
+// Read the version from the arguments
+let version = UserDefaults.standard.string(forKey: "version") ?? ""
+if version.isEmpty {
+    print("Specify version using -version argument")
+    exit(EXIT_FAILURE)
+}
+
+let templateURL = playgroundsDirectory.appendingPathComponent("SwiftShortcutsTemplate.playgroundbook")
+let playgroundURL = playgroundsDirectory.appendingPathComponent("SwiftShortcuts.playgroundbook")
+
+// Remove the old output if it was there
+if fileManager.directoryExists(at: playgroundURL) {
+    try fileManager.removeItem(at: playgroundURL)
+}
+
+// Move the template to the output
+try fileManager.copyItem(at: templateURL, to: playgroundURL)
+
+let manifestURL = playgroundURL
+    .appendingPathComponent("Contents", isDirectory: true)
+    .appendingPathComponent("Manifest.plist", isDirectory: false)
+
+// Write the version number to the manifest
+let manifestData = try Data(contentsOf: manifestURL)
+var manifest = try PropertyListSerialization.propertyList(from: manifestData, format: nil) as! [String: Any]
+manifest["ContentVersion"] = version
+try PropertyListSerialization.data(fromPropertyList: manifest, format: .xml, options: .zero).write(to: manifestURL)
+
+// Work out where we're moving source code from and to
+let sourceDirectory = playgroundsDirectory.appendingPathComponent("../Sources/SwiftShortcuts")
+let outputDirectory = playgroundURL
+    .appendingPathComponent("Contents", isDirectory: true)
+    .appendingPathComponent(isDebuggable ? "UserModules": "Modules", isDirectory: true)
+    .appendingPathComponent("SwiftShortcuts.playgroundmodule", isDirectory: true)
+    .appendingPathComponent("Sources", isDirectory: true)
+
+// Create the output directory if it does not exist yet
+if !fileManager.directoryExists(at: outputDirectory) {
+    try fileManager.createDirectory(at: outputDirectory, withIntermediateDirectories: true, attributes: nil)
+}
+
+// Create an enumerator for the source files
+let resourceKeys = Set<URLResourceKey>([.typeIdentifierKey])
+let enumerator = fileManager.enumerator(
+    at: sourceDirectory,
+    includingPropertiesForKeys: Array(resourceKeys),
+    options: .skipsHiddenFiles
+)!
+
+// Move each .swift file into the root Sources directory
+// This is because the Playgrounds app doesn't support nested directories in UserModules - FB7606658
+for case let fileURL as URL in enumerator {
+    let resourceValues = try fileURL.resourceValues(forKeys: resourceKeys)
+    guard resourceValues.typeIdentifier == "public.swift-source" else { continue }
+
+    try fileManager.copyItem(
+        at: fileURL,
+        to: outputDirectory.appendingPathComponent(fileURL.lastPathComponent, isDirectory: false)
+    )
+}
+
+print("Generated playground at '\(playgroundURL.path)'")

--- a/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Chapters/Chapter1.playgroundchapter/Manifest.plist
+++ b/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Chapters/Chapter1.playgroundchapter/Manifest.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Name</key>
+	<string>My Playground</string>
+	<key>TemplatePageFilename</key>
+	<string>Template.playgroundpage</string>
+	<key>InitialUserPages</key>
+	<array>
+		<string>My Playground.playgroundpage</string>
+	</array>
+</dict>
+</plist>

--- a/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Chapters/Chapter1.playgroundchapter/Pages/My Playground.playgroundpage/Manifest.plist
+++ b/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Chapters/Chapter1.playgroundchapter/Pages/My Playground.playgroundpage/Manifest.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Name</key>
+	<string>My Playground</string>
+	<key>LiveViewEdgeToEdge</key>
+	<false/>
+	<key>LiveViewMode</key>
+	<string>HiddenByDefault</string>
+</dict>
+</plist>

--- a/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Chapters/Chapter1.playgroundchapter/Pages/My Playground.playgroundpage/main.swift
+++ b/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Chapters/Chapter1.playgroundchapter/Pages/My Playground.playgroundpage/main.swift
@@ -1,1 +1,13 @@
 import SwiftShortcuts
+import ShortcutSupport
+import PlaygroundSupport
+
+struct HelloWorldShortcut: Shortcut {
+    var body: some Shortcut {
+        Comment("Hello, world!")
+    }
+}
+
+let shortcut = HelloWorldShortcut()
+
+PlaygroundPage.current.show(shortcut)

--- a/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Chapters/Chapter1.playgroundchapter/Pages/My Playground.playgroundpage/main.swift
+++ b/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Chapters/Chapter1.playgroundchapter/Pages/My Playground.playgroundpage/main.swift
@@ -1,0 +1,1 @@
+import SwiftShortcuts

--- a/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Chapters/Chapter1.playgroundchapter/Pages/Template.playgroundpage/Manifest.plist
+++ b/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Chapters/Chapter1.playgroundchapter/Pages/Template.playgroundpage/Manifest.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Name</key>
+	<string>Template Page</string>
+	<key>LiveViewEdgeToEdge</key>
+	<false/>
+	<key>LiveViewMode</key>
+	<string>HiddenByDefault</string>
+</dict>
+</plist>

--- a/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Chapters/Chapter1.playgroundchapter/Pages/Template.playgroundpage/main.swift
+++ b/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Chapters/Chapter1.playgroundchapter/Pages/Template.playgroundpage/main.swift
@@ -1,1 +1,3 @@
 import SwiftShortcuts
+import ShortcutSupport
+import PlaygroundSupport

--- a/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Chapters/Chapter1.playgroundchapter/Pages/Template.playgroundpage/main.swift
+++ b/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Chapters/Chapter1.playgroundchapter/Pages/Template.playgroundpage/main.swift
@@ -1,0 +1,1 @@
+import SwiftShortcuts

--- a/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Manifest.plist
+++ b/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Manifest.plist
@@ -7,7 +7,7 @@
 		<string>Chapter1.playgroundchapter</string>
 	</array>
 	<key>ContentIdentifier</key>
-	<string>ios.github.a2.swift-shortcuts</string>
+	<string>io.a2.swift-shortcuts</string>
 	<key>ContentVersion</key>
 	<string>1.0</string>
 	<key>DeploymentTarget</key>

--- a/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Manifest.plist
+++ b/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Manifest.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Chapters</key>
+	<array>
+		<string>Chapter1.playgroundchapter</string>
+	</array>
+	<key>ContentIdentifier</key>
+	<string>ios.github.a2.swift-shortcuts</string>
+	<key>ContentVersion</key>
+	<string>1.0</string>
+	<key>DeploymentTarget</key>
+	<string>ios-current</string>
+	<key>DevelopmentRegion</key>
+	<string>en</string>
+	<key>SwiftVersion</key>
+	<string>5.1</string>
+	<key>Version</key>
+	<string>7.0</string>
+	<key>UserAutoImportedAuxiliaryModules</key>
+	<array/>
+	<key>UserModuleMode</key>
+	<string>Full</string>
+</dict>
+</plist>

--- a/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Modules/ShortcutSupport.playgroundmodule/Sources/PlaygroundPage+Shortcut.swift
+++ b/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Modules/ShortcutSupport.playgroundmodule/Sources/PlaygroundPage+Shortcut.swift
@@ -1,0 +1,33 @@
+import PlaygroundSupport
+import SwiftShortcuts
+import UIKit
+
+public extension PlaygroundPage {
+    func show<S: Shortcut>(_ shortcut: S) {
+        // Construct the view controller
+        let viewController = ShortcutPreviewViewController(
+            shortcut: shortcut
+        )
+
+        // Wrap the preview within a navigation controller
+        let navigationController = UINavigationController(
+            rootViewController: viewController
+        )
+
+        // Create a new trait collection that secifies `.compact` horizontal size class
+        let traitCollection = UITraitCollection(traitsFrom: [
+            .current,
+            UITraitCollection(horizontalSizeClass: .compact)
+        ])
+
+        // Hide the nav bar, force a compact horizontal environment
+        navigationController.isNavigationBarHidden = true
+        navigationController.setOverrideTraitCollection(
+            traitCollection,
+            forChild: viewController
+        )
+
+        // Set the live view
+        liveView = navigationController
+    }
+}

--- a/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Modules/ShortcutSupport.playgroundmodule/Sources/PlaygroundPage+Shortcut.swift
+++ b/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Modules/ShortcutSupport.playgroundmodule/Sources/PlaygroundPage+Shortcut.swift
@@ -3,31 +3,10 @@ import SwiftShortcuts
 import UIKit
 
 public extension PlaygroundPage {
+    /// Shows a preview of a given shortcut with the ability to share into other apps such as Shortcuts.app.
+    ///
+    /// - Parameter shortcut: The constructed shortcut to be previewed.
     func show<S: Shortcut>(_ shortcut: S) {
-        // Construct the view controller
-        let viewController = ShortcutPreviewViewController(
-            shortcut: shortcut
-        )
-
-        // Wrap the preview within a navigation controller
-        let navigationController = UINavigationController(
-            rootViewController: viewController
-        )
-
-        // Create a new trait collection that secifies `.compact` horizontal size class
-        let traitCollection = UITraitCollection(traitsFrom: [
-            .current,
-            UITraitCollection(horizontalSizeClass: .compact)
-        ])
-
-        // Hide the nav bar, force a compact horizontal environment
-        navigationController.isNavigationBarHidden = true
-        navigationController.setOverrideTraitCollection(
-            traitCollection,
-            forChild: viewController
-        )
-
-        // Set the live view
-        liveView = navigationController
+        liveView = ShortcutPreviewViewController(shortcut: shortcut)
     }
 }

--- a/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Modules/ShortcutSupport.playgroundmodule/Sources/ShortcutPreviewViewController.swift
+++ b/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Modules/ShortcutSupport.playgroundmodule/Sources/ShortcutPreviewViewController.swift
@@ -92,8 +92,8 @@ class ShortcutPreviewViewController<S: Shortcut>: UIViewController, UIDragIntera
 
             // Additionally configure iPad popover presentation if it's ever required
             let controller = viewController.popoverPresentationController
-            controller?.sourceRect = sender.frame
-            controller?.sourceView = view
+            controller?.sourceRect = sender.bounds
+            controller?.sourceView = sender
 
             // Present the share sheet
             present(viewController, animated: true, completion: nil)

--- a/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Modules/ShortcutSupport.playgroundmodule/Sources/ShortcutPreviewViewController.swift
+++ b/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Modules/ShortcutSupport.playgroundmodule/Sources/ShortcutPreviewViewController.swift
@@ -1,0 +1,132 @@
+import SwiftShortcuts
+import UIKit
+
+class ShortcutPreviewViewController<S: Shortcut>: UIViewController, UIDragInteractionDelegate {
+    let shortcut: S
+
+    var name: String {
+        return "\(S.self)"
+    }
+
+    init(shortcut: S) {
+        self.shortcut = shortcut
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let rect = CGRect(origin: .zero, size: CGSize(width: 3.0, height: 3.0))
+        let render = UIGraphicsImageRenderer(size: rect.size)
+        let backgroundImage = render.image { context in
+            UIColor(red: 0.11, green: 0.12, blue: 0.34, alpha: 1.0).setFill()
+            UIRectFill(rect)
+        }
+        .resizableImage(withCapInsets: UIEdgeInsets(top: 1, left: 1, bottom: 1, right: 1))
+
+        let titleLabel = UILabel()
+        titleLabel.text = "Share \(name)"
+        titleLabel.font = .preferredFont(forTextStyle: .callout)
+        titleLabel.textColor = .white
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        let button = UIButton(type: .custom)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(share(_:)), for: .touchUpInside)
+        button.setBackgroundImage(backgroundImage, for: .normal)
+        button.layer.masksToBounds = true
+        button.layer.cornerRadius = 4
+        button.addInteraction(UIDragInteraction(delegate: self))
+
+        button.addSubview(titleLabel)
+        view.addSubview(button)
+        view.backgroundColor = .secondarySystemBackground
+
+        NSLayoutConstraint.activate([
+            button.centerXAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor),
+            button.centerYAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerYAnchor),
+            titleLabel.topAnchor.constraint(equalTo: button.topAnchor, constant: 6),
+            titleLabel.leadingAnchor.constraint(equalTo: button.leadingAnchor, constant: 8),
+            titleLabel.trailingAnchor.constraint(equalTo: button.trailingAnchor, constant: -8),
+            titleLabel.bottomAnchor.constraint(equalTo: button.bottomAnchor, constant: -6)
+        ])
+    }
+
+    @objc func share(_ sender: UIButton) {
+        do {
+            let fileManager = FileManager.default
+            let applicationSupport = try fileManager.url(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: false
+            )
+
+            let outputURL = applicationSupport
+                .appendingPathComponent("io.github.a2.swift-shortcuts", isDirectory: true)
+                .appendingPathComponent("\(name).shortcut", isDirectory: false)
+
+            // Remove the output directory if it already existed (clean up any old shortcuts)
+            if fileManager.fileExists(atPath: outputURL.deletingLastPathComponent().path) {
+                try fileManager.removeItem(at: outputURL.deletingLastPathComponent())
+            }
+
+            // Create the directory again
+            try fileManager.createDirectory(
+                at: outputURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
+
+            // Build the shortcut and write it to disk
+            let data = try shortcut.build()
+            try data.write(to: outputURL)
+
+            // Create an activity view controller pointing to the shortcut
+            let viewController = UIActivityViewController(
+                activityItems: [outputURL],
+                applicationActivities: nil
+            )
+
+            // Additionally configure iPad popover presentation if it's ever required
+            let controller = viewController.popoverPresentationController
+            controller?.sourceRect = sender.frame
+            controller?.sourceView = view
+
+            // Present the share sheet
+            present(viewController, animated: true, completion: nil)
+        } catch {
+            // Construct an error alert
+            let viewController = UIAlertController(
+                title: "Error Exporing",
+                message: error.localizedDescription,
+                preferredStyle: .alert
+            )
+
+            // Provide a dismiss action
+            viewController.addAction(
+                UIAlertAction(title: "Dismiss", style: .cancel, handler: nil)
+            )
+
+            // Present the alert controller
+            present(viewController, animated: true, completion: nil)
+        }
+    }
+
+    func dragInteraction(
+        _ interaction: UIDragInteraction,
+        itemsForBeginning session: UIDragSession
+    ) -> [UIDragItem] {
+        return [
+            UIDragItem(
+                itemProvider: NSItemProvider(
+                    object: ShortcutWrapper(shortcut)
+                )
+            )
+        ]
+    }
+}

--- a/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Modules/ShortcutSupport.playgroundmodule/Sources/ShortcutPreviewViewController.swift
+++ b/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Modules/ShortcutSupport.playgroundmodule/Sources/ShortcutPreviewViewController.swift
@@ -65,30 +65,28 @@ class ShortcutPreviewViewController<S: Shortcut>: UIViewController, UIDragIntera
                 appropriateFor: nil,
                 create: false
             )
-
-            let outputURL = applicationSupport
-                .appendingPathComponent("io.a2.swift-shortcuts", isDirectory: true)
-                .appendingPathComponent("\(name).shortcut", isDirectory: false)
+            let directoryURL = applicationSupport.appendingPathComponent("io.a2.swift-shortcuts", isDirectory: true)
 
             // Remove the output directory if it already existed (clean up any old shortcuts)
-            if fileManager.fileExists(atPath: outputURL.deletingLastPathComponent().path) {
-                try fileManager.removeItem(at: outputURL.deletingLastPathComponent())
+            if fileManager.fileExists(atPath: directoryURL.path) {
+                try fileManager.removeItem(at: directoryURL)
             }
 
             // Create the directory again
             try fileManager.createDirectory(
-                at: outputURL.deletingLastPathComponent(),
+                at: directoryURL,
                 withIntermediateDirectories: true,
                 attributes: nil
             )
 
             // Build the shortcut and write it to disk
-            let data = try shortcut.build()
-            try data.write(to: outputURL)
+            let shortcutURL = directoryURL.appendingPathComponent("\(name).shortcut", isDirectory: false)
+            let sortcutData = try shortcut.build()
+            try sortcutData.write(to: shortcutURL)
 
             // Create an activity view controller pointing to the shortcut
             let viewController = UIActivityViewController(
-                activityItems: [outputURL],
+                activityItems: [shortcutURL],
                 applicationActivities: nil
             )
 

--- a/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Modules/ShortcutSupport.playgroundmodule/Sources/ShortcutPreviewViewController.swift
+++ b/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Modules/ShortcutSupport.playgroundmodule/Sources/ShortcutPreviewViewController.swift
@@ -67,7 +67,7 @@ class ShortcutPreviewViewController<S: Shortcut>: UIViewController, UIDragIntera
             )
 
             let outputURL = applicationSupport
-                .appendingPathComponent("io.github.a2.swift-shortcuts", isDirectory: true)
+                .appendingPathComponent("io.a2.swift-shortcuts", isDirectory: true)
                 .appendingPathComponent("\(name).shortcut", isDirectory: false)
 
             // Remove the output directory if it already existed (clean up any old shortcuts)

--- a/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Modules/ShortcutSupport.playgroundmodule/Sources/ShortcutWrapper.swift
+++ b/Playground/SwiftShortcutsTemplate.playgroundbook/Contents/Modules/ShortcutSupport.playgroundmodule/Sources/ShortcutWrapper.swift
@@ -1,0 +1,31 @@
+import SwiftShortcuts
+import UIKit
+
+class ShortcutWrapper<S: Shortcut>: NSObject, NSItemProviderWriting {
+    let shortcut: S
+
+    init(_ shortcut: S) {
+        self.shortcut = shortcut
+        super.init()
+    }
+
+    static var writableTypeIdentifiersForItemProvider: [String] {
+        return [
+            "com.apple.shortcut"
+        ]
+    }
+
+    func loadData(
+        withTypeIdentifier typeIdentifier: String,
+        forItemProviderCompletionHandler completionHandler: @escaping (Data?, Error?) -> Void
+    ) -> Progress? {
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                completionHandler(try self.shortcut.build(), nil)
+            } catch {
+                completionHandler(nil, error)
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/SwiftShortcuts/Actions/ChooseFromMenu.swift
+++ b/Sources/SwiftShortcuts/Actions/ChooseFromMenu.swift
@@ -40,7 +40,7 @@ public struct ChooseFromMenu: Shortcut {
     /// The contents of the shortcut.
     public var body: some Shortcut {
         ShortcutGroup {
-            ControlFlowAction(identifier: identifier, groupingIdentifier: groupingIdentifier, mode: .start, userInfo: StartUserInfo(prompt: prompt, menuItems: items.map(\.label)))
+            ControlFlowAction(identifier: identifier, groupingIdentifier: groupingIdentifier, mode: .start, userInfo: StartUserInfo(prompt: prompt, menuItems: items.map({ $0.label })))
 
             ForEach(items) { item in
                 ControlFlowAction(identifier: identifier, groupingIdentifier: groupingIdentifier, mode: .middle, userInfo: MiddleUserInfo(menuItemTitle: item.label))

--- a/Sources/SwiftShortcuts/Actions/FilterFiles.swift
+++ b/Sources/SwiftShortcuts/Actions/FilterFiles.swift
@@ -102,10 +102,10 @@ extension FilterFiles {
                 switch filters {
                 case .all(let filters):
                     try valueContainer.encode(1, forKey: .filterOperator)
-                    try valueContainer.encode(filters.map(\.fileFilter), forKey: .filters)
+                    try valueContainer.encode(filters.map({ $0.fileFilter }), forKey: .filters)
                 case .any(let filters):
                     try valueContainer.encode(0, forKey: .filterOperator)
-                    try valueContainer.encode(filters.map(\.fileFilter), forKey: .filters)
+                    try valueContainer.encode(filters.map({ $0.fileFilter }), forKey: .filters)
                 }
             }
         }

--- a/Sources/SwiftShortcuts/Internal/FromAny.swift
+++ b/Sources/SwiftShortcuts/Internal/FromAny.swift
@@ -1,4 +1,8 @@
+#if os(Linux)
 import CSymbols
+#else
+import Foundation
+#endif
 
 // MARK: - AnyShortcut from Any
 
@@ -46,7 +50,17 @@ public func makeAnyShortcut<S: Shortcut>(from shortcut: S) -> AnyShortcut {
 }
 
 private typealias ShortcutToAnyShortcutFunction = @convention(thin) (UnsafeRawPointer, ProtocolConformanceRecord) -> AnyShortcut
+
+#if os(Linux)
 private let makeAnyShortcut = unsafeBitCast(makeAnyShortcutSymbol(), to: ShortcutToAnyShortcutFunction.self)
+#else
+private let makeAnyShortcut: ShortcutToAnyShortcutFunction = {
+    let symbolName = "_swift_shortcuts_makeAnyShortcut"
+    let handle = dlopen(nil, RTLD_GLOBAL)
+    let pointer = dlsym(handle, symbolName)
+    return unsafeBitCast(pointer, to: ShortcutToAnyShortcutFunction.self)
+}()
+#endif
 
 // MARK: - [ActionComponent] from Any
 
@@ -83,7 +97,16 @@ private func _decomposeIntoActions<S: Shortcut>(shortcut: S) -> [Action] {
 }
 
 private typealias ShortcutToActionsFunction = @convention(thin) (UnsafeRawPointer, ProtocolConformanceRecord) -> [Action]
+#if os(Linux)
 private let decomposeIntoActions = unsafeBitCast(decomposeIntoActionsSymbol(), to: ShortcutToActionsFunction.self)
+#else
+private let decomposeIntoActions: ShortcutToActionsFunction = {
+    let symbolName = "_swift_shortcuts_decomposeIntoActions"
+    let handle = dlopen(nil, RTLD_GLOBAL)
+    let pointer = dlsym(handle, symbolName)
+    return unsafeBitCast(pointer, to: ShortcutToActionsFunction.self)
+}()
+#endif
 
 func actionComponents(from value: Any) -> [Action]? {
     // Synthesize a fake protocol conformance record to ActionStepsConvertible


### PR DESCRIPTION
Hey! This is an awesome looking project and since it's all (mostly) written in Swift, it got me thinking about the ability to write shortcuts in Swift Playgrounds directly on the iPad 🧐 

In theory, each time you publish a new release you could also publish a zipped **.playgroundbook** bundle that could then be opened into the Swift Playgrounds app on iPad allowing people to prototype shortcuts and use them all without having to use a Mac. Is this something you'd consider? 

I did think that it was semi-pointless since you can just use Shortcuts anyway to create them using the GUI, but it might be useful for people who would prefer to express their shortcuts in code still? 

This draft PR makes a few changes that result in a working POC. I've also included the gif below to show it in action: 

![SwiftShorcutsPlayground](https://user-images.githubusercontent.com/482871/86541727-1bc82800-bf07-11ea-8c80-3e3ff306530e.gif)

(Note that I re-ran the playground because of what I _think_ is an iOS 14 bug that broke the `UIActivityViewController` on first run but I need to confirm)

So yeah ... The changes to the project itself were pretty simple:

1. Remove use of the Swift 5.2 compiler synthesised KeyPath methods (since Swift Playgrounds is currently still Swift 5.1
2. Only use CSymbols for Linux as looking at commit history, they were only introduced to fix a linux crash I think (since Swift Playgrounds only supports Swift code)

Then in addition to that, I've included a .playgroundbook template that mostly resembles a blank playground with a few extras:

1. The default page contains the Hello World example
2. ShortcutsSupport module contains helpers to extend `PlaygroundPage` as well as an internal view controller that writes the shortcut to disk and lets it be shared via `UIActivityViewController`. Sharing on iOS kinda sucks but it does the job

There is then a **GeneratePlayground.swift** script that copies the template, sets it's version based on arguments and moves the package source code into a module within the .playgroundbook. The idea is that you could run this each time you make a release then zip the output **SwiftShortcuts.playgroundbook** and include on the GitHub release.

```
$ ./Playground/GeneratePlayground.swift -version 1.0.0 -debug false
```

Anyway ... I'd be keen to see what you think about this. I'm not the biggest user of Shortcuts in general but the second that I saw this library I really wanted to see if Swift Playgrounds could be pushed to its limits and it would be interesting to see what it might enable. Cheers! 